### PR TITLE
Exclude block length limit for spec files

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -103,6 +103,10 @@ Metrics/AbcSize:
   # => cyclomatic complexity is better
   Max: 9999
 
+Metrics/BlockLength:
+  Exclude:
+    - "spec/**/*"
+
 Metrics/ClassLength:
   CountComments: false  # count full line comments?
   Max: 300


### PR DESCRIPTION
Block in tests are very often beyond the limit and it makes no sense to limit them.