### PR TITLE
disable Rubocop Style/ClassAndModuleChildren check

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -30,8 +30,8 @@ Style/ClassAndModuleChildren:
   #   class Foo::Bar
   #   end
   #
-  # The compact style is only forced, for classes or modules with one child.
-  EnforcedStyle: compact
+  # There are good reasons to use both, do not enforce this style.
+  Enabled: false
 
 Style/FrozenStringLiteralComment:
   Enabled: false


### PR DESCRIPTION
# Description
Usually, compact style is preferable but there are very good reasons to use nested style, for example when writing a standalone Ruby script.

If we force compact style in a standalone file, the following code :
```Ruby
module Lambda
  class TerraformApplyPlan
  # ...
  end
end
```

will have to become (module have to be declared first) : 
```Ruby
module Lambda
end

class Lambda::TerraformApplyPlan
  # ...
end
```

... which doesn't seem really nice 😉 