### PR TITLE
Enforce double quotes in string interpolation

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -82,6 +82,14 @@ Style/StringLiterals:
   # use the same type of quotes on each line.
   ConsistentQuotesInMultiline: true
 
+# Since we always want to enforce double quotes, having single quotes on such
+# places feels weird:
+# 
+#   "Hello, #{APP_CONFIG['little_world']"
+#
+Style/StringLiteralsInInterpolation:
+  EnforcedStyle: double_quotes
+
 #################################### Metrics ###################################
 
 # Please keep rules in alphabetical order...


### PR DESCRIPTION
https://github.com/klaxit/ruby/blob/3920aa8f72433cb0080934049b5f2aa23ef9b853/rubocop.yml#L85-L91

I personally hate this rule because it forces me to think about which quotes I should use. If enforced, we'll just always use double quotes.

👍 👎 ?