### PR TITLE
Disable Layout/EmptyLineAfterGuardClause rule

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -10,6 +10,22 @@ Layout/DotPosition:
     - leading
     - trailing
 
+Layout/EmptyLineAfterGuardClause:
+  # We disable this rule to allow each developer
+  # to choose the appropriate style.
+  #
+  # For example, the following example couldn't reach
+  # a consensus :
+  #
+  # odds = []
+  # 10.times.each do |i|
+  #   next if i % 2 == 0
+  #
+  #   odds << i
+  # end
+  #
+  Enabled: false
+
 Layout/SpaceInsideHashLiteralBraces:
   EnforcedStyle: space
   EnforcedStyleForEmptyBraces: no_space


### PR DESCRIPTION
As discussed before, the `rubocop` rule `Layout/EmptyLineAfterGuardClause` does not reach a consensus amongst us. 

For example, I am still frustrated with not beeing able to let it "as is" : 
```ruby
  def home_loc
    return nil if home_lat.nil? || home_lng.nil?
    Loc::Location[home_lat, home_lng]
  end
```

I think it is best that we disable this rule and let each one of us what is best for the things he works on.
