### PR TITLE
Avoid crashing when there is no class to test

### DIFF
--- a/danger-klaxit/Gemfile.lock
+++ b/danger-klaxit/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    danger-klaxit (0.0.1)
+    danger-klaxit (0.0.2)
       danger-plugin-api (~> 1.0)
       danger-rubocop (~> 0.6)
       parser (~> 2.6.0)
@@ -9,8 +9,8 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.6.0)
-      public_suffix (>= 2.0.2, < 4.0)
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.0)
     claide (1.0.3)
     claide-plugins (0.9.2)
@@ -87,7 +87,7 @@ GEM
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
-    public_suffix (3.1.1)
+    public_suffix (4.0.1)
     rainbow (3.0.0)
     rake (10.5.0)
     rb-fsevent (0.10.3)

--- a/danger-klaxit/lib/danger_plugin.rb
+++ b/danger-klaxit/lib/danger_plugin.rb
@@ -138,9 +138,10 @@ class Danger::DangerKlaxit < Danger::Plugin
       return public_methods_for_class_or_module(ast).values
     end
 
-    unless is_begin[ast]
-      raise ArgumentError, "Unable to parse file starting with #{ast.type}"
-    end
+    # This case happens when there is no class definition, for instance within
+    # an ActiveAdmin view file. Since we do not need tests for these kind of
+    # files, we return an empty array.
+    return [] unless is_begin[ast]
 
     ast.children
        .select(&is_class_or_module)

--- a/danger-klaxit/lib/klaxit/gem_version.rb
+++ b/danger-klaxit/lib/klaxit/gem_version.rb
@@ -1,3 +1,3 @@
 module Klaxit
-  VERSION = "0.0.1".freeze
+  VERSION = "0.0.2".freeze
 end

--- a/danger-klaxit/spec/klaxit_spec.rb
+++ b/danger-klaxit/spec/klaxit_spec.rb
@@ -131,6 +131,18 @@ module Danger
           end
           it { should contain_exactly "Fizz.noop" }
         end
+        context "when there is no class" do
+          let(:file_content) do
+            <<~RUBY
+              ActiveAdmin.register do
+                def i_m_a_method
+                  "hello little world"
+                end
+              end
+            RUBY
+          end
+          it { should be_empty }
+        end
         context "when setting `self.` method as private" do
           let(:file_content) do
             <<~RUBY


### PR DESCRIPTION
Our api encountered an issue with the public methods definition (see ci for https://github.com/klaxit/klaxit-api/pull/954). This should do the trick.