### PR TITLE
Only report new offenses

### DIFF
--- a/danger-klaxit/Gemfile.lock
+++ b/danger-klaxit/Gemfile.lock
@@ -1,9 +1,9 @@
 PATH
   remote: .
   specs:
-    danger-klaxit (0.0.2)
+    danger-klaxit (0.1.0)
       danger-plugin-api (~> 1.0)
-      danger-rubocop (~> 0.6)
+      danger-rubocop (~> 0.7)
       parser (~> 2.6.0)
 
 GEM
@@ -36,7 +36,7 @@ GEM
       terminal-table (~> 1)
     danger-plugin-api (1.0.0)
       danger (> 2.0)
-    danger-rubocop (0.6.1)
+    danger-rubocop (0.7.0)
       danger
       rubocop
     diff-lcs (1.3)

--- a/danger-klaxit/danger-klaxit.gemspec
+++ b/danger-klaxit/danger-klaxit.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "danger-plugin-api", "~> 1.0"
 
-  spec.add_runtime_dependency "danger-rubocop", "~> 0.6"
+  spec.add_runtime_dependency "danger-rubocop", "~> 0.7"
   # Parser version is specified to 2.6.0 to facilitate a migration to Ruby 2.6.
   # Moreover, a lot of Gems need this version, hence we improve compatibility
   spec.add_runtime_dependency "parser", "~> 2.6.0"

--- a/danger-klaxit/lib/danger_plugin.rb
+++ b/danger-klaxit/lib/danger_plugin.rb
@@ -21,7 +21,8 @@ class Danger::DangerKlaxit < Danger::Plugin
   def warn_rubocop
     rubocop.lint(files: git.modified_files + git.added_files,
                  inline_comment: true,
-                 force_exclusion: true)
+                 force_exclusion: true,
+                 only_report_new_offenses: true)
   end
 
   # Inspects commit messages to stop someone from merging until the committer

--- a/danger-klaxit/lib/klaxit/gem_version.rb
+++ b/danger-klaxit/lib/klaxit/gem_version.rb
@@ -1,3 +1,3 @@
 module Klaxit
-  VERSION = "0.0.2".freeze
+  VERSION = "0.1.0".freeze
 end


### PR DESCRIPTION
This PR will allow a less verbose bot. However, it needs the merge and deployment of https://github.com/ashfurrow/danger-rubocop/pull/30.

And since a gemspec file [cannot have a git branch dependency](https://stackoverflow.com/a/6499472/6320039), for now on the hack for using it it to add this to gemfiles using klaxit danger:

```ruby
gem "danger-rubocop", github: "klaxit/danger-rubocop", branch: "force-only_report_new_offences"
```

Add of course `bundle update danger-rubocop`.