### PR TITLE
Exclude file unchecked by rubocop from spec verification

### DIFF
--- a/danger-klaxit/lib/klaxit/gem_version.rb
+++ b/danger-klaxit/lib/klaxit/gem_version.rb
@@ -1,3 +1,3 @@
 module Klaxit
-  VERSION = "0.1.0".freeze
+  VERSION = "0.1.1".freeze
 end

--- a/danger-klaxit/spec/klaxit_spec.rb
+++ b/danger-klaxit/spec/klaxit_spec.rb
@@ -178,6 +178,27 @@ module Danger
           it { should contain_exactly "Buzz.pub" }
         end
       end
+
+      describe "#new_ruby_files_excluding_spec_and_rubocop" do
+        before do
+          allow(@plugin).to receive(:new_ruby_files_excluding_spec) do
+            %W(db/migrate/mimimi.rb #{Dir.pwd}/script/rm_rf_slash.rb app/good.rb)
+          end
+
+          FileUtils.mv(".rubocop.yml", ".rubocop.yml.copy")
+          IO.write(".rubocop.yml", <<~YAML)
+            AllCops:
+              Exclude:
+                - db/**/*
+                - script/**/*
+          YAML
+        end
+        after do
+          FileUtils.mv(".rubocop.yml.copy", ".rubocop.yml")
+        end
+        subject { @plugin.send(:new_ruby_files_excluding_spec_and_rubocop) }
+        it { should contain_exactly "app/good.rb" }
+      end
     end
   end
 end


### PR DESCRIPTION
# Description

Avoid messages such as:

> ⚠️ No spec found for file db/migrate/20190907421053_you_will_not_know.rb.

We want to check for missing specs only in files that RuboCop would check in our project. 

# Note

The non-trivial part was running into RuboCop source code to
get the config generation:

```ruby
rubocop_config = RuboCop::ConfigStore.new.for(".")
```

A best solution would be to have rubocop check for missing specs itself!