### PR TITLE
Avoid crash when there is a `class << self` with only one method

### DIFF
--- a/danger-klaxit/Gemfile.lock
+++ b/danger-klaxit/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    danger-klaxit (0.1.0)
+    danger-klaxit (0.1.2)
       danger-plugin-api (~> 1.0)
       danger-rubocop (~> 0.7)
       parser (~> 2.6.0)

--- a/danger-klaxit/lib/danger_plugin.rb
+++ b/danger-klaxit/lib/danger_plugin.rb
@@ -179,7 +179,7 @@ class Danger::DangerKlaxit < Danger::Plugin
     # We do not handle `self.` within sclass (`class << self`) nor nested
     # sclass since it would be bad practif anyway.
     # See https://stackoverflow.com/q/57570175/6320039.
-    ast_node.children.last.children.each do |sub_node|
+    children_for_node(ast_node).each do |sub_node|
       break if sub_node.type == :send && sub_node.children[1] == :private
       next if sub_node.type != :def
 

--- a/danger-klaxit/lib/klaxit/gem_version.rb
+++ b/danger-klaxit/lib/klaxit/gem_version.rb
@@ -1,3 +1,3 @@
 module Klaxit
-  VERSION = "0.1.1".freeze
+  VERSION = "0.1.2".freeze
 end

--- a/danger-klaxit/spec/klaxit_spec.rb
+++ b/danger-klaxit/spec/klaxit_spec.rb
@@ -82,6 +82,19 @@ module Danger
           @plugin.send(:public_methods_for_file, file_content).map(&:to_s)
         end
         it { should contain_exactly "Foo#some_method" }
+        context "when there is only one class method" do
+          let(:file_content) do
+            <<~RUBY
+              class Foo
+                class << self
+                  def create
+                  end
+                end
+              end
+            RUBY
+          end
+          it { should contain_exactly "Foo.create" }
+        end
         context "with nested modules and classes" do
           let(:file_content) do
             <<~RUBY


### PR DESCRIPTION
Fixes danger for klaxit/klaxit-api#968. You can take a peak at the new non-regression spec for more details.