### PR TITLE
Avoid warning _No department given for XXX_

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -1,9 +1,6 @@
 # Override default Rubocop confg
 # See https://github.com/bbatsov/rubocop
 
-Documentation:
-  Enabled: false
-
 Layout/DotPosition:
   EnforcedStyle: leading
 
@@ -47,6 +44,9 @@ Style/ClassAndModuleChildren:
   #   end
   #
   # There are good reasons to use both, do not enforce this style.
+  Enabled: false
+
+Style/Documentation:
   Enabled: false
 
 Style/FrozenStringLiteralComment:


### PR DESCRIPTION
See [this so post](https://stackoverflow.com/a/58220572/6320039) for details!

The annoying warning is:
> klaxit-rubocop: Warning: no department given for Documentation.