### PR TITLE
rubocop: Disable Style/NegatedIf

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -68,6 +68,10 @@ Style/HashSyntax:
   # Do not suggest { a?: 1 } over { :a? => 1 } in ruby19 style
   PreferHashRocketsForNonAlnumEndingSymbols: false
 
+# Do not enforce usage of `unless foo` over `if !foo`
+Style/NegatedIf:
+  Enabled: false
+
 Style/NumericPredicate:
   # Disabled : depending on the context, we think it's a good thing
   # to have the choice between `> 0` and `positive?`.


### PR DESCRIPTION
The rubocop rule [`Style/NegatedIf`][rule] can sometimes generate code harder to understand with `unless` than with `if`:

```ruby
do_stuff unless var.nil? # reads _do stuff unless var is nil_
do_stuff if !var.nil? # reads _do stuff if var is not nil_  which is clearer IMHO
```

Discussing it with @ThomasKlaxit, we both write `if` condition first, then negate it, then write `unless`, which is a no-brainer. I think that it may look prettier, but is harder to grasp.

What is your opinion about that? (👍 👎, or detailed answer!)

[rule]: https://rubocop.readthedocs.io/en/latest/cops_style/#stylenegatedif