### PR TITLE
Enforce `frozen_string_literal` comment usage

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -49,9 +49,6 @@ Style/ClassAndModuleChildren:
 Style/Documentation:
   Enabled: false
 
-Style/FrozenStringLiteralComment:
-  Enabled: false
-
 Style/HashSyntax:
   EnforcedStyle: ruby19_no_mixed_keys
   SupportedStyles:


### PR DESCRIPTION
In most of my pull requests I ask for usage of:

```ruby
# frozen_string_literal: true

foo = "text"
```

rather than:

```ruby
foo = "text".freeze
```

Moreover, this as great chances of being a default behavior in the next ruby major, and is a better behavior (IMO).

Lastly, the default behavior of this rule allows to **not use frozen strings** by using the top comment with a `false` value.

All that said, I suggest we go back to the default setting of [Style/FrozenStringLiteralComment][rule].


What is your opinion ? React 👍 👎or detail your answer!

[rule]: https://rubocop.readthedocs.io/en/stable/cops_style/#stylefrozenstringliteralcomment