### PR TITLE
Feature: Add active record rubocop cops

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -133,5 +133,5 @@ Metrics/MethodLength:
   Max: 20
 
 require:
-  - ./lib/rubocop/cop/active_record/bang.rb
-  - ./lib/rubocop/cop/active_record/update_attribute.rb
+  - ./rubocop/cop/active_record/bang.rb
+  - ./rubocop/cop/active_record/update_attribute.rb

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -131,3 +131,7 @@ Metrics/ModuleLength:
 Metrics/MethodLength:
   CountComments: false  # count full line comments?
   Max: 20
+
+require:
+  - ./lib/rubocop/cop/active_record/bang.rb
+  - ./lib/rubocop/cop/active_record/update_attribute.rb

--- a/rubocop/cop/active_record/bang.rb
+++ b/rubocop/cop/active_record/bang.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module ActiveRecord
+      class Bang < RuboCop::Cop::Cop
+        PATTERN = "(send _ #bang_method? ...)"
+        
+        METHODS = {
+          update_attributes: "{lvar hash}",
+          update: "{lvar hash}",
+          create: "{lvar hash} ?",
+          save: "{lvar hash} ?",
+          decrement: "{str sym lvar} {int lvar}",
+          destroy: "",
+          toogle: "{str sym lvar}",
+          becomes: "{const lvar}"
+        }.map do |method, arguments|
+          [
+            method,
+            NodePattern.new(
+              PATTERN.sub("#bang_method?", ":#{method}")
+                     .sub("...", arguments)
+            )
+          ]
+        end.to_h.freeze
+
+        MSG = "Prefer the use of the bang method '%s!'. " \
+              "Exceptions are our friends !"
+
+        def_node_matcher :bangable_method?, PATTERN
+
+        def on_send(node)
+          bangable_method?(node) do
+            if METHODS[@method_name].match(node)
+              add_offense(
+                node,
+                location: :selector,
+                message: format(MSG, @method_name)
+              )
+            end
+          end
+        end
+
+        def bang_method?(arg_name)
+          return false unless METHODS.key?(arg_name)
+          @method_name = arg_name
+          true
+        end
+
+        def autocorrect(node)
+          lambda do |corrector|
+            ctx = node.children[0] ? "#{node.children[0].source}." : ""
+            corrector.replace(
+              node.loc.expression,
+              node.source.sub(
+                "#{ctx}#{node.children[1]}",
+                "#{ctx}#{@method_name}!"
+              )
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/rubocop/cop/active_record/bang.rb
+++ b/rubocop/cop/active_record/bang.rb
@@ -5,7 +5,7 @@ module RuboCop
     module ActiveRecord
       class Bang < RuboCop::Cop::Cop
         PATTERN = "(send _ #bang_method? ...)"
-        
+
         METHODS = {
           update_attributes: "{lvar hash}",
           update: "{lvar hash}",
@@ -26,7 +26,7 @@ module RuboCop
         end.to_h.freeze
 
         MSG = "Prefer the use of the bang method '%s!'. " \
-              "Exceptions are our friends !"
+              "Exceptions are our friends!"
 
         def_node_matcher :bangable_method?, PATTERN
 

--- a/rubocop/cop/active_record/update_attribute.rb
+++ b/rubocop/cop/active_record/update_attribute.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module ActiveRecord
+      class UpdateAttribute < RuboCop::Cop::Cop
+        MSG = "Prefer the use of 'update_column' to force " \
+              "the update of a column and skip the validation."
+
+        def_node_matcher :update_attribute_method?, <<~PATTERN
+          (
+            send _ {:update_attribute! :update_attribute} {str sym lvar} _
+          )
+        PATTERN
+
+        def on_send(node)
+          update_attribute_method?(node) do
+            add_offense(node, location: :selector)
+          end
+        end
+
+        def autocorrect(node)
+          lambda do |corrector|
+            ctx = node.children[0] ? "#{node.children[0].source}." : ""
+            corrector.replace(
+              node.loc.expression,
+              node.source.sub(
+                "#{ctx}#{node.children[1]}",
+                "#{ctx}update_column"
+              )
+            )
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add rubocop ActiveRecord  cop.
- Warning about using `update_attribute` instead of `update_column`.
- Warning to use methods without `!`: (update_attributes, update:, create, save, decrement, destroy, toogle, becomes)