### PR TITLE
Feature: Rename ruby-klaxit to rubocop-klaxit

### DIFF
--- a/rubocop-klaxit/rubocop-klaxit.gemspec
+++ b/rubocop-klaxit/rubocop-klaxit.gemspec
@@ -3,7 +3,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "gem_version"
 
 Gem::Specification.new do |spec|
-  spec.name          = "ruby-klaxit"
+  spec.name          = "rubocop-klaxit"
   spec.version       = Klaxit::VERSION
   spec.authors       = ["Hugo BARTHELEMY"]
   spec.email         = ["dev@klaxit.com"]


### PR DESCRIPTION
**Rename `ruby-klaxit` to `rubocop-klaxit`** 🖍
The gem was originally to include all subjects. Now that it only manages Rubocop, it seems more logical to rename it to rubocop-klaxit.
