### PR TITLE
Fix: More lax on rubocop version

### DIFF
--- a/rubocop-klaxit/rubocop-klaxit.gemspec
+++ b/rubocop-klaxit/rubocop-klaxit.gemspec
@@ -16,5 +16,5 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["rubocop/*"]
 
-  spec.add_runtime_dependency "rubocop", "~> 0.74"
+  spec.add_runtime_dependency "rubocop", [">= 0.44", "< 1"]
 end


### PR DESCRIPTION
> **More lax on rubocop version** 🚦
> We can be more lax about the version of Rubocop used. This will allow us to have fewer conflicts.
