### PR TITLE
fix Klaxit::VERSION namespace clash

### DIFF
--- a/danger-klaxit/danger-klaxit.gemspec
+++ b/danger-klaxit/danger-klaxit.gemspec
@@ -1,10 +1,12 @@
+# frozen_string_literal: true
+
 lib = File.expand_path("lib", __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require "klaxit/gem_version"
+require "klaxit/danger/gem_version"
 
 Gem::Specification.new do |spec|
   spec.name          = "danger-klaxit"
-  spec.version       = Klaxit::VERSION
+  spec.version       = Klaxit::Danger::VERSION
   spec.authors       = ["Ulysse Buonomo"]
   spec.email         = ["dev@klaxit.com"]
   spec.summary       = "Danger for Klaxit projects."

--- a/danger-klaxit/lib/klaxit/danger/gem_version.rb
+++ b/danger-klaxit/lib/klaxit/danger/gem_version.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Klaxit
+  module Danger
+    VERSION = "0.1.2"
+  end
+end

--- a/danger-klaxit/lib/klaxit/gem_version.rb
+++ b/danger-klaxit/lib/klaxit/gem_version.rb
@@ -1,3 +1,0 @@
-module Klaxit
-  VERSION = "0.1.2".freeze
-end

--- a/rubocop-klaxit/lib/klaxit/rubocop/gem_version.rb
+++ b/rubocop-klaxit/lib/klaxit/rubocop/gem_version.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
 module Klaxit
-  VERSION = "0.1.0".freeze
+  module Rubocop
+    VERSION = "0.1.0"
+  end
 end

--- a/rubocop-klaxit/rubocop-klaxit.gemspec
+++ b/rubocop-klaxit/rubocop-klaxit.gemspec
@@ -1,10 +1,10 @@
 lib = File.expand_path("lib", __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require "gem_version"
+require "klaxit/rubocop/gem_version"
 
 Gem::Specification.new do |spec|
   spec.name          = "rubocop-klaxit"
-  spec.version       = Klaxit::VERSION
+  spec.version       = Klaxit::Rubocop::VERSION
   spec.authors       = ["Hugo BARTHELEMY"]
   spec.email         = ["dev@klaxit.com"]
   spec.summary       = "Ruby rules for Klaxit projects."


### PR DESCRIPTION
Use different namespaces for gem versions.

Without this, when you use both gems in a project, it redefines the `Klaxit::VERSION` constant and causes problems with bundler & cache.