### PR TITLE
Feature: Add Rails/SaveBang rubocop cop

### DIFF
--- a/rubocop-klaxit/Gemfile
+++ b/rubocop-klaxit/Gemfile
@@ -1,3 +1,5 @@
 source "https://rubygems.org"
 
+gem "rubocop-rails", require: false
+
 gemspec

--- a/rubocop-klaxit/Gemfile.lock
+++ b/rubocop-klaxit/Gemfile.lock
@@ -1,0 +1,55 @@
+PATH
+  remote: .
+  specs:
+    rubocop-klaxit (0.1.0)
+      rubocop (>= 0.44, < 1)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activesupport (6.0.2.2)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+      zeitwerk (~> 2.2)
+    ast (2.4.0)
+    concurrent-ruby (1.1.6)
+    i18n (1.8.2)
+      concurrent-ruby (~> 1.0)
+    jaro_winkler (1.5.4)
+    minitest (5.14.0)
+    parallel (1.19.1)
+    parser (2.7.0.5)
+      ast (~> 2.4.0)
+    rack (2.2.2)
+    rainbow (3.0.0)
+    rexml (3.2.4)
+    rubocop (0.80.1)
+      jaro_winkler (~> 1.5.1)
+      parallel (~> 1.10)
+      parser (>= 2.7.0.1)
+      rainbow (>= 2.2.2, < 4.0)
+      rexml
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 1.7)
+    rubocop-rails (2.5.0)
+      activesupport
+      rack (>= 1.1)
+      rubocop (>= 0.72.0)
+    ruby-progressbar (1.10.1)
+    thread_safe (0.3.6)
+    tzinfo (1.2.6)
+      thread_safe (~> 0.1)
+    unicode-display_width (1.6.1)
+    zeitwerk (2.3.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  rubocop-klaxit!
+  rubocop-rails
+
+BUNDLED WITH
+   2.1.4

--- a/rubocop-klaxit/cops/active-record/update_attribute.rb
+++ b/rubocop-klaxit/cops/active-record/update_attribute.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module ActiveRecord
+      class UpdateAttribute < RuboCop::Cop::Cop
+        MSG = "Prefer the use of 'update_column' to force " \
+              "the update of a column and skip the validation."
+
+        def_node_matcher :update_attribute_method?, <<~PATTERN
+          (
+            send _ {:update_attribute! :update_attribute} {str sym lvar} _
+          )
+        PATTERN
+
+        # Called when a message is sending (when a method is called)
+        def on_send(node)
+          update_attribute_method?(node) do
+            add_offense(node, location: :selector)
+          end
+        end
+
+        # Fixes the error, replace 'update_attribute' by 'update_column'
+        def autocorrect(node)
+          lambda do |corrector|
+            ctx = node.children[0] ? "#{node.children[0].source}." : ""
+            corrector.replace(
+              node.loc.expression,
+              node.source.sub(
+                "#{ctx}#{node.children[1]}",
+                "#{ctx}update_column"
+              )
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/rubocop-klaxit/rubocop.rb
+++ b/rubocop-klaxit/rubocop.rb
@@ -1,3 +1,4 @@
 # frozen_string_literal: true
 
 require_relative "cops/specify_low_queue_in_migration"
+require_relative "cops/active-record/update_attribute"

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -1,3 +1,6 @@
+
+require: rubocop-rails
+
 # Override default Rubocop confg
 # See https://github.com/bbatsov/rubocop
 
@@ -134,3 +137,126 @@ Metrics/ModuleLength:
 Metrics/MethodLength:
   CountComments: false  # count full line comments?
   Max: 20
+
+# Enable only rule on the use of ActiveRecord save methods without bang!
+Rails/SaveBang:
+  Enabled: true
+# Disable other Rails cops for now
+Rails/ActionFilter:
+  Enabled: false
+Rails/ActiveRecordAliases:
+  Enabled: false
+Rails/ActiveRecordOverride:
+  Enabled: false
+Rails/ActiveSupportAliases:
+  Enabled: false
+Rails/ApplicationController:
+  Enabled: false
+Rails/ApplicationJob:
+  Enabled: false
+Rails/ApplicationMailer:
+  Enabled: false
+Rails/ApplicationRecord:
+  Enabled: false
+Rails/AssertNot:
+  Enabled: false
+Rails/BelongsTo:
+  Enabled: false
+Rails/Blank:
+  Enabled: false
+Rails/BulkChangeTable:
+  Enabled: false
+Rails/CreateTableWithTimestamps:
+  Enabled: false
+Rails/Date:
+  Enabled: false
+Rails/Delegate:
+  Enabled: false
+Rails/DelegateAllowBlank:
+  Enabled: false
+Rails/DynamicFindBy:
+  Enabled: false
+Rails/EnumHash:
+  Enabled: false
+Rails/EnumUniqueness:
+  Enabled: false
+Rails/EnvironmentComparison:
+  Enabled: false
+Rails/Exit:
+  Enabled: false
+Rails/FilePath:
+  Enabled: false
+Rails/FindBy:
+  Enabled: false
+Rails/FindEach:
+  Enabled: false
+Rails/HasAndBelongsToMany:
+  Enabled: false
+Rails/HasManyOrHasOneDependent:
+  Enabled: false
+Rails/HelperInstanceVariable:
+  Enabled: false
+Rails/HttpPositionalArguments:
+  Enabled: false
+Rails/HttpStatus:
+  Enabled: false
+Rails/IgnoredSkipActionFilterOption:
+  Enabled: false
+Rails/IndexBy:
+  Enabled: false
+Rails/IndexWith:
+  Enabled: false
+Rails/InverseOf:
+  Enabled: false
+Rails/LexicallyScopedActionFilter:
+  Enabled: false
+Rails/LinkToBlank:
+  Enabled: false
+Rails/NotNullColumn:
+  Enabled: false
+Rails/Output:
+  Enabled: false
+Rails/OutputSafety:
+  Enabled: false
+Rails/PluralizationGrammar:
+  Enabled: false
+Rails/Presence:
+  Enabled: false
+Rails/Present:
+  Enabled: false
+Rails/RakeEnvironment:
+  Enabled: false
+Rails/ReadWriteAttribute:
+  Enabled: false
+Rails/RedundantAllowNil:
+  Enabled: false
+Rails/RedundantReceiverInWithOptions:
+  Enabled: false
+Rails/ReflectionClassName:
+  Enabled: false
+Rails/RefuteMethods:
+  Enabled: false
+Rails/RelativeDateConstant:
+  Enabled: false
+Rails/RequestReferer:
+  Enabled: false
+Rails/ReversibleMigration:
+  Enabled: false
+Rails/SafeNavigation:
+  Enabled: false
+Rails/SafeNavigationWithBlank:
+  Enabled: false
+Rails/ScopeArgs:
+  Enabled: false
+Rails/SkipsModelValidations:
+  Enabled: false
+Rails/TimeZone:
+  Enabled: false
+Rails/UniqBeforePluck:
+  Enabled: false
+Rails/UniqueValidationWithoutIndex:
+  Enabled: false
+Rails/UnknownEnv:
+  Enabled: false
+Rails/Validation:
+  Enabled: false


### PR DESCRIPTION
**Rubocop: Add Rails/SaveBang cop** 👮‍♀️
Add Rubocop warning on the bang-free ActiveRecord persistences methods when they are used.
Also added a rule on the use of `update-attribute` method, instead of `update_column`. 
