### PR TITLE
Add `run_brakeman_scanner` command to danger

### DIFF
--- a/danger-klaxit/Gemfile.lock
+++ b/danger-klaxit/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     danger-klaxit (0.1.2)
+      danger-brakeman_scanner (~> 0.1)
       danger-plugin-api (~> 1.0)
       danger-rubocop (~> 0.7)
       parser (~> 2.6.0)
@@ -12,6 +13,7 @@ GEM
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.0)
+    brakeman (4.8.0)
     claide (1.0.3)
     claide-plugins (0.9.2)
       cork
@@ -21,32 +23,36 @@ GEM
     colored2 (3.1.2)
     cork (0.3.0)
       colored2 (~> 3.1)
-    danger (6.0.9)
+    danger (6.3.2)
       claide (~> 1.0)
       claide-plugins (>= 0.9.2)
       colored2 (~> 3.1)
       cork (~> 0.1)
       faraday (~> 0.9)
       faraday-http-cache (~> 2.0)
-      git (~> 1.5)
+      git (~> 1.6)
       kramdown (~> 2.0)
       kramdown-parser-gfm (~> 1.0)
       no_proxy_fix
       octokit (~> 4.7)
       terminal-table (~> 1)
+    danger-brakeman_scanner (0.1.0)
+      brakeman
+      danger
     danger-plugin-api (1.0.0)
       danger (> 2.0)
-    danger-rubocop (0.7.0)
+    danger-rubocop (0.7.1)
       danger
       rubocop
     diff-lcs (1.3)
-    faraday (0.15.4)
+    faraday (0.17.3)
       multipart-post (>= 1.2, < 3)
     faraday-http-cache (2.0.0)
       faraday (~> 0.8)
     ffi (1.11.1)
     formatador (0.2.5)
-    git (1.5.0)
+    git (1.6.0)
+      rchardet (~> 1.8)
     guard (2.15.0)
       formatador (>= 0.2.4)
       listen (>= 2.7, < 4.0)
@@ -78,7 +84,8 @@ GEM
     notiffany (0.1.3)
       nenv (~> 0.1)
       shellany (~> 0.0)
-    octokit (4.14.0)
+    octokit (4.18.0)
+      faraday (>= 0.9)
       sawyer (~> 0.8.0, >= 0.5.3)
     open4 (1.3.4)
     parallel (1.17.0)
@@ -87,12 +94,13 @@ GEM
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
-    public_suffix (4.0.1)
+    public_suffix (4.0.4)
     rainbow (3.0.0)
     rake (13.0.1)
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
       ffi (~> 1.0)
+    rchardet (1.8.0)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
       rspec-expectations (~> 3.8.0)
@@ -129,7 +137,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  bundler (~> 2.0.2)
+  bundler (~> 2.0)
   danger-klaxit!
   guard (~> 2.14)
   guard-rspec (~> 4.7)
@@ -140,4 +148,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.0.2
+   2.1.4

--- a/danger-klaxit/README.md
+++ b/danger-klaxit/README.md
@@ -26,6 +26,8 @@ Dont forget to also [add danger to your CI][doc-danger-ci]!
   there are two commits with the same name.
 - **klaxit.warn_for_public_methods_without_specs** — will write inline comment
   for a new public method that has no spec.
+- **klaxit.run_brakeman_scanner** — will write a markdown report if there is a
+  brakeman issue. This should only be used in rails or active_record projects.
 
 
 

--- a/danger-klaxit/danger-klaxit.gemspec
+++ b/danger-klaxit/danger-klaxit.gemspec
@@ -12,21 +12,24 @@ Gem::Specification.new do |spec|
   spec.summary       = "Danger for Klaxit projects."
   spec.homepage      = "https://github.com/klaxit/ruby"
   spec.license       = "MIT"
+  spec.metadata["yard.run"] = "yri" # use "yard" to build full HTML docs.
 
   spec.files         = `git ls-files`.split($INPUT_RECORD_SEPARATOR)
-  spec.executables   = spec.files.grep(%r(^bin/)) { |f| File.basename(f) }
+  spec.executables   = spec.files.grep(%r(^bin/), &File.method(:basename))
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "danger-plugin-api", "~> 1.0"
 
+  spec.add_runtime_dependency "danger-brakeman_scanner", "~> 0.1"
   spec.add_runtime_dependency "danger-rubocop", "~> 0.7"
+
   # Parser version is specified to 2.6.0 to facilitate a migration to Ruby 2.6.
   # Moreover, a lot of Gems need this version, hence we improve compatibility
   spec.add_runtime_dependency "parser", "~> 2.6.0"
 
   # General ruby development
-  spec.add_development_dependency "bundler", "~> 2.0.2"
+  spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 13.0"
 
   # Testing support

--- a/danger-klaxit/lib/klaxit/danger/gem_version.rb
+++ b/danger-klaxit/lib/klaxit/danger/gem_version.rb
@@ -2,6 +2,6 @@
 
 module Klaxit
   module Danger
-    VERSION = "0.1.2"
+    VERSION = "0.2.0"
   end
 end

--- a/danger-klaxit/spec/support/fixtures/klaxit-example-app/app/models/user.rb
+++ b/danger-klaxit/spec/support/fixtures/klaxit-example-app/app/models/user.rb
@@ -1,0 +1,5 @@
+class User < ActiveRecord::Base
+  def dangerous(user_input_column)
+    User.connection.select_values("SELECT #{user_input_column} FROM users")
+  end
+end


### PR DESCRIPTION
Now `klaxit.common` has brakeman power. This will work only if a rails app is detected (if there is an `app/` folder).

You can see a preview in klaxit/klaxit-matcher#371.