### PR TITLE
Remove fix: Force Rails version for Brakeman when in a Sinatra project

### DIFF
--- a/danger-klaxit/lib/danger_plugin.rb
+++ b/danger-klaxit/lib/danger_plugin.rb
@@ -58,10 +58,6 @@ class Danger::DangerKlaxit < Danger::Plugin
   # the current path, and klaxit naming conventions (i.e `klaxit-<name>`).
   def run_brakeman_scanner(configs = { app_path: "." })
     configs[:github_repo] = github_repo.to_s if github_repo
-    # Brakeman is unable to detect active_record version from a Sinatra project.
-    # Hence this trick until a solution is found!
-    # https://github.com/presidentbeef/brakeman/issues/1494
-    configs[:rails5] ||= true if sinatra_project?
     brakeman_scanner.run(configs)
   end
 
@@ -138,10 +134,6 @@ class Danger::DangerKlaxit < Danger::Plugin
   # Sinatra or Rails project.
   def rails_like_project?
     Dir.exist?("app")
-  end
-
-  def sinatra_project?
-    File.read("Gemfile.lock").match?(/\s{4}sinatra\s/)
   end
 
   def github_repo

--- a/danger-klaxit/spec/klaxit_spec.rb
+++ b/danger-klaxit/spec/klaxit_spec.rb
@@ -299,9 +299,7 @@ module Danger
 
         before do
           allow(@plugin).to receive(:github_repo) { github_repo }
-          allow(@plugin).to receive(:File) { file }
           allow(@dangerfile).to receive(:brakeman_scanner) { brakeman_scanner }
-          allow(File).to receive(:read).with("Gemfile.lock") { gemfile_lock }
         end
 
         around do |example|
@@ -311,32 +309,9 @@ module Danger
         it "runs brakeman with correct arguments" do
           expect(brakeman_scanner).to receive(:run).with(
             app_path: ".",
-            github_repo: "klaxit/klaxit-example-app"
+            github_repo: github_repo
           )
           @plugin.run_brakeman_scanner
-        end
-
-        context "when in a Sinatra project" do
-          let(:gemfile_lock) do
-            <<~GEMFILE
-              GEM
-                remote: https://rubygems.org/
-                specs:
-                  activemodel (x.x.x)
-                    activesupport (= x.x.x)
-                  sinatra (x.x.x)
-                  activerecord (x.x.x)
-                    activemodel (= x.x.x)
-            GEMFILE
-          end
-          it "should force Rails version" do
-            expect(brakeman_scanner).to receive(:run).with(
-              app_path: ".",
-              github_repo: github_repo,
-              rails5: true
-            )
-            @plugin.run_brakeman_scanner
-          end
         end
       end
 


### PR DESCRIPTION
Following the fix https://github.com/presidentbeef/brakeman/pull/1506, we no longer need to force the version of Rails for Sinatra projects. Brakeman can now use the ActiveRecord version instead.

Revert of commit https://github.com/klaxit/ruby/pull/35/commits/3cff8d2699ee3a67c03d97c6c3eb5ecc02aa7ac9
