### PR TITLE
Check structure.sql and schema.sql

### DIFF
--- a/danger-klaxit/README.md
+++ b/danger-klaxit/README.md
@@ -30,6 +30,9 @@ Dont forget to also [add danger to your CI][doc-danger-ci]!
   modified `config/config.yml` is not ordered
 - **klaxit.run_brakeman_scanner** — will write a markdown report if there is a
   brakeman issue. This should only be used in rails or active_record projects.
+- **klaxit.warn_for_not_updated_structure_sql** -- will write inline comments
+  if there is migrations but structure.sql is not updated or the migrations
+  timestamps are not added
 
 
 

--- a/danger-klaxit/README.md
+++ b/danger-klaxit/README.md
@@ -30,7 +30,7 @@ Dont forget to also [add danger to your CI][doc-danger-ci]!
   modified `config/config.yml` is not ordered
 - **klaxit.run_brakeman_scanner** — will write a markdown report if there is a
   brakeman issue. This should only be used in rails or active_record projects.
-- **klaxit.warn_for_not_updated_structure_sql** -- will write inline comments
+- **klaxit.fail_for_not_updated_structure_sql** -- will fail
   if there is migrations but structure.sql is not updated or the migrations
   timestamps are not added
 

--- a/danger-klaxit/lib/danger_plugin.rb
+++ b/danger-klaxit/lib/danger_plugin.rb
@@ -19,6 +19,7 @@ class Danger::DangerKlaxit < Danger::Plugin
     warn_for_public_methods_without_specs
     warn_for_bad_order_in_config
     warn_rubocop
+    warn_for_not_updated_structure_sql
     run_brakeman_scanner if rails_like_project?
   end
 
@@ -119,12 +120,25 @@ class Danger::DangerKlaxit < Danger::Plugin
     MARKDOWN
   end
 
-  def warn_for_not_impacted_migration
+  def warn_for_not_updated_structure_sql
     migration_files = (git.added_files - %w(Dangerfile)).grep(%r(db/migrate))
     return nil if migration_files.empty?
 
-    if git.modified_files.grep(%r(db/structure.sql|db/schema.rb$)).empty?
-      fail("You should commit your databases changes via `structure.sql` or `schema.rb` when your do a migration.")
+    if git.modified_files.grep(%r(db/structure.sql)).empty?
+      warn("You should commit your databases changes via `structure.sql` or `schema.rb` when your do a migration.")
+    end
+
+    added_migrations_timestamps = migration_files.map do |elt|
+      File.basename(elt).partition("_").first
+    end
+
+    structure_diff = git.diff_for_file("db/structure.sql").patch
+    missing_timestamps = added_migrations_timestamps.reject do |ts|
+      structure_diff.include?(ts)
+    end
+
+    unless missing_timestamps.empty?
+      warn("Some migrations timestamps are missing: #{missing_timestamps.join(", ")}")
     end
   end
 

--- a/danger-klaxit/lib/danger_plugin.rb
+++ b/danger-klaxit/lib/danger_plugin.rb
@@ -125,7 +125,8 @@ class Danger::DangerKlaxit < Danger::Plugin
     return nil if migration_files.empty?
 
     if git.modified_files.grep(%r(db/structure.sql)).empty?
-      warn("You should commit your databases changes via `structure.sql` or `schema.rb` when your do a migration.")
+      warn("You should commit your databases changes via `structure.sql` when you do a migration.")
+      return nil
     end
 
     added_migrations_timestamps = migration_files.map do |elt|

--- a/danger-klaxit/lib/danger_plugin.rb
+++ b/danger-klaxit/lib/danger_plugin.rb
@@ -119,6 +119,15 @@ class Danger::DangerKlaxit < Danger::Plugin
     MARKDOWN
   end
 
+  def warn_for_not_impacted_migration
+    migration_files = (git.added_files - %w(Dangerfile)).grep(%r(db/migrate))
+    return nil if migration_files.empty?
+
+    if git.modified_files.grep(%r(db/structure.sql|db/schema.rb$)).empty?
+      fail("You should commit your databases changes via `structure.sql` or `schema.rb` when your do a migration.")
+    end
+  end
+
   private
 
   def new_ruby_files_excluding_spec

--- a/danger-klaxit/spec/klaxit_spec.rb
+++ b/danger-klaxit/spec/klaxit_spec.rb
@@ -292,27 +292,30 @@ module Danger
         end
       end
 
-      describe "#warn_for_not_updated_structure_sql" do
+      describe "#fail_for_not_updated_structure_sql" do
+        let(:structure_sql_diff) { "" }
+        let(:schema_rb_diff) { "" }
         before do
           allow(@plugin.git).to receive(:added_files) { added_files }
           allow(@plugin.git).to receive(:modified_files) { modified_files }
           allow(@plugin.git).to receive(:diff_for_file) do |file|
             if file == "db/structure.sql"
               double(:diff, patch: structure_sql_diff)
+            elsif file == "db/schema.rb"
+              double(:diff, patch: schema_rb_diff)
             end
           end
         end
-        context "when structure.sql is not updated" do
+        context "when structure.sql and schema.rb are not updated" do
           let(:migration_number) { rand(1..1000) }
           let(:added_files) { ["db/migrate/#{migration_number}_a_migration.rb"] }
           let(:modified_files) { [] }
-          let(:structure_sql_diff) { "" }
 
-          it "should warn structure.sql is not updated" do
-            @plugin.warn_for_not_updated_structure_sql
-            expect(@dangerfile.status_report[:warnings])
+          it "should warn structure.sql or schema.rb is not updated" do
+            @plugin.fail_for_not_updated_structure_sql
+            expect(@dangerfile.status_report[:errors])
               .to include("You should commit your databases changes via" \
-                " `structure.sql` when you do a migration.")
+                " `structure.sql` or `schema.rb` when you do a migration.")
           end
         end
 
@@ -322,9 +325,9 @@ module Danger
           let(:modified_files) { ["db/structure.sql"] }
           let(:structure_sql_diff) { "#{rand(1000..2000)}" }
 
-          it "should warn structure.sql is not updated" do
-            @plugin.warn_for_not_updated_structure_sql
-            expect(@dangerfile.status_report[:warnings])
+          it "should warn structure.sql is not up to date with migrations" do
+            @plugin.fail_for_not_updated_structure_sql
+            expect(@dangerfile.status_report[:errors])
               .to include(
                 "Some migrations timestamps are missing: #{migration_number}"
               )
@@ -338,7 +341,32 @@ module Danger
           let(:structure_sql_diff) { "#{migration_number}" }
 
           it "should not warn" do
-            @plugin.warn_for_not_updated_structure_sql
+            @plugin.fail_for_not_updated_structure_sql
+            expect(@plugin.status_report.values).to all be_empty
+          end
+        end
+        context "when schema.rb is updated" do
+          let(:migration_number) { "#{rand(1..1000)}_#{rand(1..1000)}" }
+          let(:added_files) { ["db/migrate/#{migration_number}_migration.rb"] }
+          let(:modified_files) { ["db/schema.rb"] }
+          let(:schema_rb_diff) { "+ version: #{rand(1..1000)})" }
+
+          it "should warn schema.rb is not up to date with migrations" do
+            @plugin.fail_for_not_updated_structure_sql
+            expect(@dangerfile.status_report[:errors])
+              .to include(
+                "Version of schema.rb is not equal to most recent added migration"
+              )
+          end
+        end
+        context "when schema.rb is updated and has migration timestamp" do
+          let(:migration_number) { "#{rand(1..1000)}_#{rand(1..1000)}" }
+          let(:added_files) { ["db/migrate/#{migration_number.tr("_", "")}_migration.rb"] }
+          let(:modified_files) { ["db/schema.rb"] }
+          let(:schema_rb_diff) { "+ version: #{migration_number})" }
+
+          it "should not fail" do
+            @plugin.fail_for_not_updated_structure_sql
             expect(@plugin.status_report.values).to all be_empty
           end
         end


### PR DESCRIPTION
Add method to check structure.sql/schema.rb and migrations:
- Verify that structure.sql or schema.rb is updated when migrations are added
- Verify structure.sql contains timestamps of new migrations
- Verify schema.rb contains timestamp of last migration