### PR TITLE
Fix: force the character limit per line

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -134,3 +134,6 @@ Metrics/ModuleLength:
 Metrics/MethodLength:
   CountComments: false  # count full line comments?
   Max: 20
+
+Layout/LineLength:
+  Max: 80


### PR DESCRIPTION
There seems to be a problem with the https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/IfUnlessModifier rule preventing having a `if/unless` statement on multiple lines. This one doesn't take into account the default maximum line size value to allow a multi-line statement.
By explicitly adding this limit, the cop is correctly applied and is disabled if the inlined expression exceeds the limit.