### PR TITLE
Feat - Danger config exclude workers/migrations new file spec

### DIFF
--- a/danger-klaxit/lib/danger_plugin.rb
+++ b/danger-klaxit/lib/danger_plugin.rb
@@ -196,6 +196,7 @@ class Danger::DangerKlaxit < Danger::Plugin
         new_ruby_files_excluding_spec
           .reject { |file| rubocop_config.file_to_exclude?(file) }
           .reject { |file| file.start_with?("db/") }
+          .reject { |file| file.start_with?("app/workers/migrations/") }
       end
   end
 

--- a/danger-klaxit/spec/klaxit_spec.rb
+++ b/danger-klaxit/spec/klaxit_spec.rb
@@ -398,7 +398,10 @@ module Danger
       describe "#new_ruby_files_excluding_spec_rubocop_and_migrations" do
         before do
           allow(@plugin).to receive(:new_ruby_files_excluding_spec) do
-            %W(db/migrate/mimimi.rb #{Dir.pwd}/script/rm_rf_slash.rb app/workers/migrations/migration.rb app/good.rb)
+            %W(
+              db/migrate/mimimi.rb #{Dir.pwd}/script/rm_rf_slash.rb 
+              app/workers/migrations/migration.rb app/good.rb
+            )
           end
 
           FileUtils.mv(".rubocop.yml", ".rubocop.yml.copy")

--- a/danger-klaxit/spec/klaxit_spec.rb
+++ b/danger-klaxit/spec/klaxit_spec.rb
@@ -398,7 +398,7 @@ module Danger
       describe "#new_ruby_files_excluding_spec_rubocop_and_migrations" do
         before do
           allow(@plugin).to receive(:new_ruby_files_excluding_spec) do
-            %W(db/migrate/mimimi.rb #{Dir.pwd}/script/rm_rf_slash.rb app/good.rb)
+            %W(db/migrate/mimimi.rb #{Dir.pwd}/script/rm_rf_slash.rb app/workers/migrations/migration.rb app/good.rb)
           end
 
           FileUtils.mv(".rubocop.yml", ".rubocop.yml.copy")


### PR DESCRIPTION
We don’t want to raise alert if we add new `workers/migrations` without `spec` file.