### PR TITLE
Feat - Use Style/MutableConstant strict rule

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -72,6 +72,11 @@ Style/HashSyntax:
   # Do not suggest { a?: 1 } over { :a? => 1 } in ruby19 style
   PreferHashRocketsForNonAlnumEndingSymbols: false
 
+# Do not assign mutable objects to constants.
+Style/MutableConstant:
+  Enabled: true
+  EnforcedStyle: strict
+
 # Do not enforce usage of `unless foo` over `if !foo`
 Style/NegatedIf:
   Enabled: false


### PR DESCRIPTION
We want to use Style/MutableConstant strict rule

https://www.rubydoc.info/github/bbatsov/RuboCop/RuboCop/Cop/Style/MutableConstant

By default we already had literals version.
