### PR TITLE
Fix config_sorter diff

### DIFF
--- a/danger-klaxit/lib/klaxit/config_sorter.rb
+++ b/danger-klaxit/lib/klaxit/config_sorter.rb
@@ -256,7 +256,7 @@ module Klaxit
       require "tempfile"
       new_file = Tempfile.new(["new_config.", ".yml"])
       new_file.write(sorted_file)
-      result = `git diff --word-diff --no-index -- #{file} #{new_file.path}`.gsub(
+      result = `git diff --no-index -- #{file} #{new_file.path}`.gsub(
         no_slash_beginning(new_file.path),
         no_slash_beginning(file)
       )


### PR DESCRIPTION
The word diff format is not correctly understood by GitHub Markdown,
hence a simple diff is just clearer.

# before

```diff
diff --git a/config/config.yml b/blop
index 9fff68e6e..b451d214f 100644
--- a/config/config.yml
+++ b/blop
@@ -110,8 +110,8 @@ DEFAULTS: &DEFAULTS
  sidekiq_status_expiration:         <%= (ENV["SIDEKIQ_STATUS_EXPIRATION"] || 900).to_i %>
  sidekiq_supervision_pool_size:     <%= ENV["SIDEKIQ_SUPERVISION_POOL_SIZE"] %>
  silent_notification_prefix:        <%= ENV["SILENT_NOTIFICATION_PREFIX"] || "SILENT --" %>
[-  slack_ops_channel:                 <%= ENV["SLACK_OPS_CHANNEL"] %>-]
  slack_oauth_token:                 <%= ENV["SLACK_OAUTH_TOKEN"] %>
  {+slack_ops_channel:                 <%= ENV["SLACK_OPS_CHANNEL"] %>+}
  snitch_mailchimp_update_all_ended: <%= ENV["SNITCH_MAILCHIMP_UPDATE_ALL_ENDED"] %>
  snitch_nightly_ended:              <%= ENV["SNITCH_NIGHTLY_ENDED"] %>
```

# after

```diff
diff --git a/config/config.yml b/blop
index 9fff68e6e..b451d214f 100644
--- a/config/config.yml
+++ b/blop
@@ -110,8 +110,8 @@ DEFAULTS: &DEFAULTS
   sidekiq_status_expiration:         <%= (ENV["SIDEKIQ_STATUS_EXPIRATION"] || 900).to_i %>
   sidekiq_supervision_pool_size:     <%= ENV["SIDEKIQ_SUPERVISION_POOL_SIZE"] %>
   silent_notification_prefix:        <%= ENV["SILENT_NOTIFICATION_PREFIX"] || "SILENT --" %>
-  slack_ops_channel:                 <%= ENV["SLACK_OPS_CHANNEL"] %>
   slack_oauth_token:                 <%= ENV["SLACK_OAUTH_TOKEN"] %>
+  slack_ops_channel:                 <%= ENV["SLACK_OPS_CHANNEL"] %>
   snitch_mailchimp_update_all_ended: <%= ENV["SNITCH_MAILCHIMP_UPDATE_ALL_ENDED"] %>
   snitch_nightly_ended:              <%= ENV["SNITCH_NIGHTLY_ENDED"] %>
```