### PR TITLE
Ensure migrations with add_index has disable_ddl_migration!

### DIFF
--- a/rubocop-klaxit/cops/active-record/no_transaction_on_add_index_migration.rb
+++ b/rubocop-klaxit/cops/active-record/no_transaction_on_add_index_migration.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module ActiveRecord
+      # Ensure migrations which add indexes are always outside transactions
+      # with disable_ddl_transaction!
+      class NoTransactionOnAddIndexMigration < Cop
+        MSG = "Migrations which add indexes should not be in transactions"
+
+        def_node_matcher :is_migration?, <<~PATTERN
+          (class _ `(const (const nil? :ActiveRecord) :Migration) _)
+        PATTERN
+
+        def_node_search :has_send_with_sym?, <<~PATTERN
+          (send nil? %1 ...)
+        PATTERN
+
+        def on_class(node)
+          return unless is_migration?(node) &&
+                        has_send_with_sym?(node, :add_index)
+          return if has_send_with_sym?(node, :disable_ddl_transaction!)
+
+          add_offense(node)
+        end
+      end
+    end
+  end
+end

--- a/rubocop-klaxit/rubocop.rb
+++ b/rubocop-klaxit/rubocop.rb
@@ -3,6 +3,7 @@
 require_relative "cops/specify_low_queue_in_migration"
 require_relative "cops/active-record/update_attribute"
 require_relative "cops/active-record/no_active_record_rollback_raise"
+require_relative "cops/active-record/no_transaction_on_add_index_migration"
 require_relative "cops/active-record/save_bang"
 require_relative "cops/check_path_documented"
 require_relative "cops/postgresql/no_between"

--- a/rubocop-klaxit/spec/cops/active-record/no_transaction_on_add_index_migration_spec.rb
+++ b/rubocop-klaxit/spec/cops/active-record/no_transaction_on_add_index_migration_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::ActiveRecord::NoTransactionOnAddIndexMigration, :config do
+  context "when it is a migration with add_index" do
+    it "registers an offense when disable_ddl_transaction! not specified" do
+      expect_offense(<<~RUBY)
+        class Foo < ActiveRecord::Migration
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Migrations which add indexes should not be in transactions
+          def change
+            add_index :foo, :bar
+          end
+        end
+      RUBY
+    end
+    it "accepts when disable_ddl_transaction! specified" do
+      expect_no_offenses(<<~RUBY)
+        class Foo < ActiveRecord::Migration
+          disable_ddl_transaction!
+          def change
+            add_index :foo, :bar
+          end
+        end
+      RUBY
+    end
+  end
+
+  it "accepts when it is not a migration" do
+    expect_no_offenses(<<~RUBY)
+      class Foo < Bar
+        def change
+          add_index :foo, :bar
+        end
+      end
+    RUBY
+  end
+  it "accepts when it is a migration without add_index" do
+    expect_no_offenses(<<~RUBY)
+      class Foo < ActiveRecord::Migration
+        def change
+          add_column :foo, :bar, :text
+        end
+      end
+    RUBY
+  end
+end


### PR DESCRIPTION
Add new rule to ensure migrations that add indexes come outside of transactions with `disable_ddl_migration!`. This is to ensure that there will be no downtime when deploying.