### PR TITLE
Bump gem versions

### DIFF
--- a/danger-klaxit/danger-klaxit.gemspec
+++ b/danger-klaxit/danger-klaxit.gemspec
@@ -24,9 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "danger-brakeman_scanner", "~> 0.1"
   spec.add_runtime_dependency "danger-rubocop", "~> 0.7"
 
-  # Parser version is specified to 2.6.0 to facilitate a migration to Ruby 2.6.
-  # Moreover, a lot of Gems need this version, hence we improve compatibility
-  spec.add_runtime_dependency "parser", "~> 2.6.0"
+  spec.add_runtime_dependency "parser", "~> 3.0"
 
   # General ruby development
   spec.add_development_dependency "bundler", "~> 2.0"

--- a/rubocop-klaxit/rubocop-klaxit.gemspec
+++ b/rubocop-klaxit/rubocop-klaxit.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["rubocop/*"]
 
-  spec.add_runtime_dependency "rubocop", [">= 0.44", "< 1"]
+  spec.add_runtime_dependency "rubocop", "~> 1.25"
 
   spec.add_development_dependency "rspec"
 end

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -1,6 +1,10 @@
 # Override default Rubocop confg
 # See https://github.com/bbatsov/rubocop
 
+AllCops:
+  NewCops: enable
+  SuggestExtensions: false
+
 Layout/DotPosition:
   EnforcedStyle: leading
 


### PR DESCRIPTION
Bump version dependencies to be able to use new RuboCop functionalities in AST node matching.