### PR TITLE
Fix/newer timestamp master

### DIFF
--- a/danger-klaxit/lib/danger_plugin.rb
+++ b/danger-klaxit/lib/danger_plugin.rb
@@ -121,15 +121,15 @@ class Danger::DangerKlaxit < Danger::Plugin
     MARKDOWN
   end
 
+  # Check all migrations were saved in schema/structure file
   def fail_for_not_updated_structure_sql
     migration_files = git.added_files.grep(%r(db/migrate))
     return nil if migration_files.empty?
 
     modified_files = git.modified_files
     structure_file = modified_files.grep(%r(db/structure.sql)).first
-    schema_file = modified_files.grep(%r(db/schema.rb)).first unless structure_file
-
-    unless structure_file || schema_file
+    schema_file_exists = File.exist?("./db/schema.rb")
+    unless structure_file || schema_file_exists
       return failure("You should commit your databases changes via" \
                      " `structure.sql` or `schema.rb` when you do a migration.")
     end
@@ -138,25 +138,39 @@ class Danger::DangerKlaxit < Danger::Plugin
       File.basename(file).partition("_").first
     end
 
-    if schema_file
-      version = git.diff_for_file(schema_file).patch.match(/^\+.*version: (.*?)\)/)[1]
-      unless version.tr("_", "") == added_migrations_timestamps.max
-        failure("Version of schema.rb is not equal to most recent added migration")
-      end
-      return nil
+    if schema_file_exists
+      return fail_for_not_updated_schema(added_migrations_timestamps.max)
     end
 
+    fail_for_missing_structure_timestamp(added_migrations_timestamps)
+  end
+
+  private
+
+  def fail_for_missing_structure_timestamp(added_migrations_timestamps)
     structure_diff = git.diff_for_file("db/structure.sql").patch
     missing_timestamps = added_migrations_timestamps.reject do |ts|
       structure_diff.include?(ts)
     end
-
     return if missing_timestamps.empty?
 
-    failure("Some migrations timestamps are missing: #{missing_timestamps.join(", ")}")
+    failure("Some migrations timestamps are missing: " \
+            "#{missing_timestamps.join(", ")}")
   end
 
-  private
+  def fail_for_not_updated_schema(max_added_migrations_timestamp)
+    version_line = File.open("./db/schema.rb") do |f|
+      f.find { _1[/^.*version: (.*?)\)/] }
+    end
+    version = version_line[/^.*version: (.*?)\)/, 1] if version_line
+    failure("Could not find version in schema file") unless version
+
+    unless version.tr("_", "") >= max_added_migrations_timestamp
+      failure("Version of schema.rb should be equal or higher than last " \
+              "added migration timestamp")
+    end
+    return nil
+  end
 
   def new_ruby_files_excluding_spec
     @new_ruby_files_excluding_spec ||= begin

--- a/danger-klaxit/lib/danger_plugin.rb
+++ b/danger-klaxit/lib/danger_plugin.rb
@@ -135,7 +135,7 @@ class Danger::DangerKlaxit < Danger::Plugin
     end
 
     added_migrations_timestamps = migration_files.map do |file|
-      File.basename(file).partition("_").first
+      File.basename(file).rpartition("_").first.tr("_", "")
     end
 
     if schema_file_exists
@@ -163,8 +163,7 @@ class Danger::DangerKlaxit < Danger::Plugin
       f.find { _1[/^.*version: (.*?)\)/] }
     end
     version = version_line[/^.*version: (.*?)\)/, 1] if version_line
-    failure("Could not find version in schema file") unless version
-
+    return failure("Could not find version in schema file") unless version
     unless version.tr("_", "") >= max_added_migrations_timestamp
       failure("Version of schema.rb should be equal or higher than last " \
               "added migration timestamp")


### PR DESCRIPTION
Fix false positive when migrations were correctly added but the schema timestamps was newer because of migrations from master. Now verify that the most recent added migrations is older or equal to schema.rb timestamp.

Also fix the timestamp extraction from migrations files.
