### PR TITLE
Only check ruby files in migration folder

### DIFF
--- a/danger-klaxit/lib/danger_plugin.rb
+++ b/danger-klaxit/lib/danger_plugin.rb
@@ -123,7 +123,7 @@ class Danger::DangerKlaxit < Danger::Plugin
 
   # Check all migrations were saved in schema/structure file
   def fail_for_not_updated_structure_sql
-    migration_files = git.added_files.grep(%r(db/migrate))
+    migration_files = git.added_files.grep(%r(db/migrate/.*rb))
     return nil if migration_files.empty?
 
     modified_files = git.modified_files

--- a/danger-klaxit/spec/klaxit_spec.rb
+++ b/danger-klaxit/spec/klaxit_spec.rb
@@ -349,6 +349,23 @@ module Danger
             expect(@plugin.status_report.values).to all be_empty
           end
         end
+        context "when structure.sql is updated and has migration timestamp and subfolder" do
+          let(:added_files) do
+            [
+              "db/migrate/#{migration_str}_migration.rb",
+              "db/migrate/#{migration_str}_migration/file_fixture.csv"
+            ]
+          end
+          let(:modified_files) { ["db/structure.sql"] }
+          let(:structure_sql_diff) do
+            "(#{migration_timestamp.strftime("%Y%m%d%H%M%S")})"
+          end
+
+          it "should not warn" do
+            @plugin.fail_for_not_updated_structure_sql
+            expect(@plugin.status_report.values).to all be_empty
+          end
+        end
         context "when schema.rb exist" do
           let(:added_files) { ["db/migrate/#{migration_str}_migration.rb"] }
           let(:modified_files) { ["db/schema.rb"] }


### PR DESCRIPTION
For `fail_for_not_updated_structure_sql `rule, ignore non-ruby files in migration folder.
This allow us to add fixtures without a danger error.
