### PR TITLE
Update danger-rubocop

### DIFF
--- a/danger-klaxit/danger-klaxit.gemspec
+++ b/danger-klaxit/danger-klaxit.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "danger-plugin-api", "~> 1.0"
 
   spec.add_runtime_dependency "danger-brakeman_scanner", "~> 0.1"
-  spec.add_runtime_dependency "danger-rubocop", "~> 0.7"
+  spec.add_runtime_dependency "danger-rubocop", "~> 0.10"
 
   spec.add_runtime_dependency "parser", "~> 3.0"
 

--- a/rubocop-klaxit/rubocop-klaxit.gemspec
+++ b/rubocop-klaxit/rubocop-klaxit.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["rubocop/*"]
 
-  spec.add_runtime_dependency "rubocop", "~> 1.25"
+  spec.add_runtime_dependency "rubocop", "~> 1.26"
 
   spec.add_development_dependency "rspec"
 end


### PR DESCRIPTION
Bump rubocop and rubocop-danger for ruby 3 support.
See https://github.com/rubocop/rubocop/pull/10424 and https://github.com/ashfurrow/danger-rubocop/pull/56
